### PR TITLE
Add file server over http interface for yautja interfacing.

### DIFF
--- a/Sources/baikonur/YautjaServiceCommand.swift
+++ b/Sources/baikonur/YautjaServiceCommand.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Vapor
+
+internal enum YautjaServiceCommand: String {
+    case createDirectory = "create-directory"
+    case delete = "delete"
+    case readDirectory = "read-directory"
+    case readFile = "read-file"
+    case rename = "rename"
+    case stat = "stat"
+    case writeFile = "write-file"
+
+    internal func perform(config: YautjaServiceConfiguration,
+                          arguments: YautjaServiceArguments) -> String {
+        guard let uri = arguments.uri else {
+            return ""
+        }
+
+        let url = URL(fileURLWithPath: "\(config.fsRoot)/\(uri)")
+        let isDirectory = (try? url.resourceValues(forKeys: [ .isDirectoryKey ]))?.isDirectory ?? false
+
+        switch self {
+        case .createDirectory:
+            guard !FileManager.default.fileExists(atPath: url.path) else {
+                return ""
+            }
+
+            let result = url.path.withCString { path in
+                mkdir(path, S_IRWXU | S_IRWXG | S_IRWXO)
+            }
+
+            precondition(result == 0, "Failed to create \(url), error: \(String(cString: strerror(errno))).")
+            return "create-directory \(url)"
+
+        case .delete:
+            let result = url.path.withCString { path -> Int32 in
+                isDirectory ? rmdir(path) :
+                              unlink(path)
+            }
+
+            precondition(result == 0, "Failed to delete \(url), error: \(String(cString: strerror(errno))).")
+            return "delete \(uri)"
+
+        case .readDirectory:
+            guard isDirectory,
+                  let contents = url.path.withCString({ path -> String? in
+                var contents = ""
+
+                guard let directory = opendir(path) else {
+                    return contents
+                }
+
+                while let entry = readdir(directory) {
+                    contents += "\(String(cString: &entry.pointee.d_name.0))\n"
+                }
+
+                return contents
+            }) else {
+                preconditionFailure("Failed to read directory at \(url), error: \(String(cString: strerror(errno))).")
+            }
+
+            return "read-directory \(url)\n\(contents)"
+
+        case .readFile:
+            guard !isDirectory,
+                  let contents = try? String(contentsOf: url) else {
+                return ""
+            }
+
+            return "read-file \(url)\n\(contents)"
+
+        case .rename:
+            return "rename \(url)"
+
+        case .stat:
+            return "stat \(url)"
+
+        case .writeFile:
+            return "write-file \(url)"
+        }
+
+    }
+}
+
+internal struct YautjaServiceArguments: Content {
+    internal var uri: String?
+}
+
+internal struct YautjaServiceConfiguration {
+    internal var fsRoot = String(cString: getenv("HOME"))
+}

--- a/Sources/baikonur/main.swift
+++ b/Sources/baikonur/main.swift
@@ -5,8 +5,10 @@ import Vapor
 internal typealias Option = ArgumentParser.Option
 
 internal struct ServerSessionState: ParsableCommand {
-    static private var _serverPort = 0
+    static private var _serverPort = 4000
+    static private var _yautjaConfig = YautjaServiceConfiguration()
     static private var serialQueue = DispatchQueue(label: "ServerSessionState.serialQueue")
+
     static fileprivate var serverPort: Int {
         get {
             return self.serialQueue.sync { self._serverPort }
@@ -17,15 +19,30 @@ internal struct ServerSessionState: ParsableCommand {
         }
     }
 
+    static fileprivate var yautjaConfig: YautjaServiceConfiguration {
+        get {
+            return self.serialQueue.sync { self._yautjaConfig }
+        }
+
+        set {
+            self.serialQueue.async { self._yautjaConfig = newValue }
+        }
+    }
+
     @Option(name: .shortAndLong, help: "Enter port number")
     internal var port: Int?
 
+    @Option(name: .shortAndLong, help: "File system extension root")
+    internal var fsRoot: String?
+
     mutating func run() throws {
-        guard let _port = port else {
-            preconditionFailure("Got nil for port.")
+        if let port = self.port {
+            ServerSessionState.serverPort = port
         }
 
-        ServerSessionState.serverPort = _port
+        if let fsRoot = self.fsRoot {
+            ServerSessionState.yautjaConfig.fsRoot = fsRoot
+        }
     }
 }
 
@@ -39,8 +56,15 @@ public func configure(_ app: Application) throws {
 }
 
 public func routes(_ app: Application) throws {
-    app.get { req in
-        return "Hello, world!"
+    app.get("yautja", ":command") { req -> String in
+        guard let _command = req.parameters.get("command"),
+              let command = YautjaServiceCommand(rawValue: _command),
+              let serviceArguments = try? req.query.decode(YautjaServiceArguments.self) else {
+            return ""
+        }
+
+        return command.perform(config: ServerSessionState.yautjaConfig,
+                               arguments: serviceArguments)
     }
 }
 
@@ -51,6 +75,26 @@ try LoggingSystem.bootstrap(from: &env)
 let app = Application(env)
 
 defer { app.shutdown() }
+
+let corsConfiguration = CORSMiddleware.Configuration(allowedOrigin: .all,
+                                                     allowedMethods: [
+                                                         .GET,
+                                                         .POST,
+                                                     ],
+                                                     allowedHeaders: [
+                                                         .accept,
+                                                         .accessControlAllowOrigin,
+                                                         .authorization,
+                                                         .contentType,
+                                                         .origin,
+                                                         .userAgent,
+                                                         .xRequestedWith,
+                                                     ])
+let corsMiddleware = CORSMiddleware(configuration: corsConfiguration)
+var middleware = Middlewares()
+
+middleware.use(corsMiddleware)
+app.middleware = middleware
 
 ServerSessionState.main()
 try configure(app)


### PR DESCRIPTION
A new namespace called `yautja` is introduced that provides the following file server functions:
1. create-directory
2. delete
3. read-directory
4. read-file
5. rename (to be implemented)
6. stat (to be implemented)
7. write-file (to be implemented)

4/7 server functions are implemented as they are simple [command + uri] pairings.

FS API reference for yautja/vscode that this patch was implemented for is located at https://github.com/microsoft/vscode-web-playground/blob/main/src/memfs.ts.